### PR TITLE
Scoreboard 7seg tweaks

### DIFF
--- a/world_stage/static/css/scoreboard.css
+++ b/world_stage/static/css/scoreboard.css
@@ -98,7 +98,7 @@
 
 .voting-card-country {
     font-size: 0.75em;
-    font-weight: bold;
+    /*font-weight: bold;*/
 }
 
 #points-row {


### PR DESCRIPTION
Changed flag size to match native resolution of the SVG.
Darkened scoreboard background to make numbers stand out more, also brightened the numbers themselves from a dark orange to a brighter orange-yellow.
Removed the voting country name being written in bold.